### PR TITLE
Be more defensive about extracting zipfiles

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -116,6 +116,7 @@ class PluginUpdater
       FileUtils.rm(file)
     end
     # Then unzip into the Git directory
+    puts "==> Extracting the latest release from the archive file..."
     extract_zip(@zip_file, Dir.pwd)
     puts "==> Committing and tagging the repo with full tag..."
     commit_and_tag

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -30,6 +30,10 @@ end
 class WordPressPluginDownloadError < PluginUpdateError
 end
 
+# Could not unzip the .zip file for a given plugin.
+class WordPressPluginUnzipError < PluginUpdateError
+end
+
 # Could not perform Git action on repo. Only useful for interacting with remotes.
 class GitError < PluginUpdateError
 end
@@ -205,6 +209,8 @@ class PluginUpdater
         zipfile.extract(entry, destination_path)
       end
     end
+  rescue => e
+    raise WordPressPluginUnzipError, e.message
   end
 end
 
@@ -316,6 +322,10 @@ class PluginLibraryUpdater
       rescue WordPressPluginJSONContainsError => e
         @failed_updates[plugin.slug] =
           e.message.empty? ? "wordpress.org reported an error #{plugin.slug}" : "#{e.message} #{e.reason}"
+        next plugin
+      rescue WordPressPluginUnzipError => e
+        @failed_updates[plugin.slug] =
+          e.message.empty? ? "could not unzip archive for #{plugin.slug}" : e.message
         next plugin
       end
       if !plugin.repos_need_updating?

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -324,6 +324,10 @@ class PluginLibraryUpdater
         @failed_updates[plugin.slug] =
           e.message.empty? ? "wordpress.org reported an error #{plugin.slug}" : "#{e.message} #{e.reason}"
         next plugin
+      rescue WordPressPluginDownloadError => e
+        @failed_updates[plugin.slug] =
+          e.message.empty? ? "could not download archive for #{plugin.slug}" : e.message
+        next plugin
       rescue WordPressPluginUnzipError => e
         @failed_updates[plugin.slug] =
           e.message.empty? ? "could not unzip archive for #{plugin.slug}" : e.message


### PR DESCRIPTION
In Incident 201 we found that the Two-Factor plugin did not mirror correctly. We could not reproduce the error, but noted that had it been caused by a corrupted .zip file, we would not have caught the error. This commit corrects that by catching errors on unzipping archive files and adding the error to the failure list at the end of the log, e.g.:

    ==> Failed to update the following 1 plugin(s):
    *** Two-Factor failed to update with message:
    Zip end of central directory signature not found

This PR also adds a little more text to the logs and one more explicit `rescue` (which will be harder to test).

### Testing

1. Follow the instructions in the README about dry-running the code. You may want to comment out lines 137-139 in this branch (to avoid deleting files). Do this once to get at least one .zip file downloaded
2. Corrupt the .zip file with something like `truncate -s 50k Two-Factor-v0.9.1.zip`
3. Comment out the line of code that downloads the .zip file (line 109 in this branch) and the line that clones the repo (or just delete your local clone)
4. Re-run the script and check that you get an error in the logs like the one above