### PR TITLE
Make local testing easier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,8 @@ GH_ACCOUNT_USERNAME=github-account-username
 GH_ACCOUNT_TOKEN=github-account-token
 # Boolean to indicate dry_run mode for local dev use - remove or set to false in prod
 DRY_RUN_MIRROR=true
+# Boolean to stop the mirror script cloning GitHub repositories. Useful for local testing.
+NO_CLONE_MIRROR=false
 # Boolean to force all repos to re-sync, regardless of whether they are already fully mirrored. Can be used if e.g. we wish to add additional tags during the mirror process. Should generally be set to false, or removed altogether
 FORCE_UPDATE_MIRROR=false
 # Edit repository topics, even in dry-run mode. Use to manage repo metadata when not actually pushing to repos.

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ GH_ACCOUNT_TOKEN=github-account-token
 DRY_RUN_MIRROR=true
 # Boolean to stop the mirror script cloning GitHub repositories. Useful for local testing.
 NO_CLONE_MIRROR=false
+# Boolean to stop the mirror script downloading .zip files from wordpress.org. Useful for local testing.
+NO_DOWNLOAD_MIRROR=false
 # Boolean to force all repos to re-sync, regardless of whether they are already fully mirrored. Can be used if e.g. we wish to add additional tags during the mirror process. Should generally be set to false, or removed altogether
 FORCE_UPDATE_MIRROR=false
 # Edit repository topics, even in dry-run mode. Use to manage repo metadata when not actually pushing to repos.

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -99,9 +99,13 @@ class PluginUpdater
   end
 
   def update_github_mirror
-    puts "==> Cloning the #{@slug} GitHub repo..."
-    `git clone #{construct_github_https_url} #{@full_path_to_clone}`
-    raise GitError, "Could not clone #{@github_url}" unless $CHILD_STATUS.success?
+    if do_not_clone?
+      puts "==> Skipping 'git clone...' since the NO_CLONE_MIRROR variable is set"
+    else
+      puts "==> Cloning the #{@slug} GitHub repo..."
+      `git clone #{construct_github_https_url} #{@full_path_to_clone}`
+      raise GitError, "Could not clone #{@github_url}" unless $CHILD_STATUS.success?
+    end
 
     puts "==> Fetching and extracting latest release from wordpress.org"
     raise WordPressPluginApiError, "No download link available for #{@slug}" if @wordpress_download_link.nil?
@@ -415,6 +419,10 @@ end
 
 def force_annotation?
   ENV["FORCE_ANNOTATION"] == "true"
+end
+
+def do_not_clone?
+  ENV["NO_CLONE_MIRROR"] == "true"
 end
 
 puts "==> -- Dry run mode --" if dry_run?

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -134,9 +134,13 @@ class PluginUpdater
 
   def cleanup
     puts "==> Cleaning up downloaded files..."
-    `rm -rf #{@zip_file}`
-    `rm -rf #{@full_path_to_clone}`
-    `rm -rf #{@tmp_files_for_plugin}`
+    if dry_run?
+      puts "... -- Dry run mode, leaving downloaded files so they can be manually verified --"
+    else
+      `rm -rf #{@zip_file}`
+      `rm -rf #{@full_path_to_clone}`
+      `rm -rf #{@tmp_files_for_plugin}`
+    end
   end
 
   private

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -202,7 +202,12 @@ class PluginUpdater
   end
 
   def download_wordpress_zip(zip_file)
-    `curl -s #{@wordpress_download_link} --output #{zip_file}`
+    if do_not_download?
+      puts "==> Skipping download of .zip file since NO_DOWNLOAD_MIRROR variable is set"
+    else
+      puts "==> Downloading #{@wordpress_download_link}..."
+      `curl -s #{@wordpress_download_link} --output #{zip_file}`
+    end
   rescue => e
     raise WordPressPluginDownloadError, e.message
   end
@@ -423,6 +428,10 @@ end
 
 def do_not_clone?
   ENV["NO_CLONE_MIRROR"] == "true"
+end
+
+def do_not_download?
+  ENV["NO_DOWNLOAD_MIRROR"] == "true"
 end
 
 puts "==> -- Dry run mode --" if dry_run?

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -206,6 +206,10 @@ class PluginUpdater
       puts "==> Skipping download of .zip file since NO_DOWNLOAD_MIRROR variable is set"
     else
       puts "==> Downloading #{@wordpress_download_link}..."
+      response_code = `curl -o /dev/null -s -I -w "%{http_code}" #{@wordpress_download_link}`.chomp
+      if response_code != "200"
+        raise WordPressPluginDownloadError, "#{@wordpress_download_link} does not return a 200 OK response"
+      end
       `curl -s #{@wordpress_download_link} --output #{zip_file}`
     end
   rescue => e


### PR DESCRIPTION
Fixes #51 

This PR:

* Changes the behaviour of `DRY_RUN_MIRROR` so that a dry run does not clean up downloaded files (the .zip file from WordPress and the cloned repository).
* Adds a `NO_CLONE_MIRROR` env var to switch of `git clone` (for local testing)
* Adds a `NO_DOWNLOAD_MIRROR` env var to switch off downloading .zip files (for local testing)
* Explicitly tests whether the link to the .zip from WordPress returns a 200 OK. If it does not, this is now caught by the `rescue` in the `extract_zip` method but that only tells us that the archive could not be extracted. If the archive link is a 404 (for example) `curl` will download an ASCII text notice which cannot be treated as a .zip file. So this change just gives us a better error message.

This PR does not:

* Refactor the code. This script is getting quite complex, but when we come to adding a new script to remove the `skip-mirror` tag I'll start factoring out common code.

### Testing

Set up your `.env` file with `DRY_RUN_MIRROR`, `NO_CLONE_MIRROR` and `NO_DOWNLOAD_MIRROR` all set to 'true' and run the script, you should see output like this:

```shell
❯ ./mirror-wordpress-plugins --dry-run
==> -- Dry run mode --
==> Fetching all GitHub plugin repositories in the library...
==> Found 786 plugins in the library

-----------------------------------------------------------------------
==> Checking status of Two-Factor...
==> Querying GitHub for latest version ...
==> Querying api.wordpress.org for latest version ...
==> Two-Factor is v0.9.1 on WordPress and v0.9.1 on GitHub
...which is already up to date with WordPress.org
...mirroring to it now
==> Skipping 'git clone...' since the NO_CLONE_MIRROR variable is set
==> Fetching and extracting latest release from wordpress.org
==> Skipping download of .zip file since NO_DOWNLOAD_MIRROR variable is set
==> Deleting existing files in the repo
==> Extracting the latest release from the archive file...
==> Cleaning up downloaded files...
... -- Dry run mode, leaving downloaded files so they can be manually verified --

-----------------------------------------------------------------------
```

Next, change line 209 in this branch to break the download like, for example:

```diff
diff --git a/mirror-wordpress-plugins b/mirror-wordpress-plugins
index 99ba353..9a3b753 100755
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -206,7 +206,7 @@ class PluginUpdater
       puts "==> Skipping download of .zip file since NO_DOWNLOAD_MIRROR variable is set"
     else
       puts "==> Downloading #{@wordpress_download_link}..."
-      response_code = `curl -o /dev/null -s -w "%{http_code}" #{@wordpress_download_link}`.chomp
+      response_code = `curl -o /dev/null -s -w "%{http_code}" #{@wordpress_download_link}b0rk`.chomp
       if response_code != "200"
         raise WordPressPluginDownloadError, "#{@wordpress_download_link} does not return a 200 OK response"
       end
```

Set `NO_DOWNLOAD_MIRROR` to be `false` and run the script again. You should see an error message like this:

```shell
❯ ./mirror-wordpress-plugins --dry-run
==> -- Dry run mode --
==> Fetching all GitHub plugin repositories in the library...
==> Found 786 plugins in the library

-----------------------------------------------------------------------
==> Checking status of Two-Factor...
==> Querying GitHub for latest version ...
==> Querying api.wordpress.org for latest version ...
==> Two-Factor is v0.9.1 on WordPress and v0.9.1 on GitHub
...which is already up to date with WordPress.org
...mirroring to it now
==> Skipping 'git clone...' since the NO_CLONE_MIRROR variable is set
==> Fetching and extracting latest release from wordpress.org
==> Downloading https://downloads.wordpress.org/plugin/two-factor.0.9.1.zip...
==> Cleaning up downloaded files...
... -- Dry run mode, leaving downloaded files so they can be manually verified --

-----------------------------------------------------------------------
==> Failed to update the following 1 plugin(s):

*** Two-Factor failed to update with message:
https://downloads.wordpress.org/plugin/two-factor.0.9.1.zip does not return a 200 OK response

-----------------------------------------------------------------------
==> Mirroring plugins took: 0m14s.
```