### PR TITLE
Validate plugin checksums

### DIFF
--- a/apply-major-version-tags
+++ b/apply-major-version-tags
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require_relative "./lib/error_mixin"
+
 require "bundler/setup"
 require "dotenv"
 require "English"
@@ -9,18 +11,6 @@ require "time"
 require "zip"
 
 Dotenv.load
-
-# Generic error class, can be caught but should not be raised.
-class PluginUpdateError < StandardError
-end
-
-# Could not find a latest version tag for the plugin
-class MissingVersionError < PluginUpdateError
-end
-
-# Could not perform Git action on repo. Only useful for interacting with remotes.
-class GitError < PluginUpdateError
-end
 
 # A Plugin is a representation of a GitHub repository that mirrors a
 # plugin from wordpress.org. Plugins are responsible for updating

--- a/lib/error_mixin.rb
+++ b/lib/error_mixin.rb
@@ -31,6 +31,10 @@ end
 class MissingVersionError < PluginUpdateError
 end
 
+# Checksum data not found at wordpress.org for a given plugin.
+class WordPressPluginChecksumsNotFound < PluginUpdateError
+end
+
 # A plugin file did not have the same checksum as the equivalent file on wordpress.org.
 class WordPressPluginChecksumMismatchError < PluginUpdateError
 end

--- a/lib/error_mixin.rb
+++ b/lib/error_mixin.rb
@@ -1,0 +1,32 @@
+# Generic error class, can be caught but should not be raised.
+class PluginUpdateError < StandardError
+end
+
+# Could not retrieve information about a given plugin.
+class WordPressPluginApiError < PluginUpdateError
+end
+
+# Could retrieve API information but it included an error.
+class WordPressPluginJSONContainsError < PluginUpdateError
+  attr_reader :reason
+  def initialize(msg = "Error from wordpress.org", reason = "")
+    @reason = reason
+    super(msg)
+  end
+end
+
+# Could not download a .zip file for a given plugin.
+class WordPressPluginDownloadError < PluginUpdateError
+end
+
+# Could not unzip the .zip file for a given plugin.
+class WordPressPluginUnzipError < PluginUpdateError
+end
+
+# Could not perform Git action on repo. Only useful for interacting with remotes.
+class GitError < PluginUpdateError
+end
+
+# Could not find a latest version tag for the plugin
+class MissingVersionError < PluginUpdateError
+end

--- a/lib/error_mixin.rb
+++ b/lib/error_mixin.rb
@@ -30,3 +30,7 @@ end
 # Could not find a latest version tag for the plugin
 class MissingVersionError < PluginUpdateError
 end
+
+# A plugin file did not have the same checksum as the equivalent file on wordpress.org.
+class WordPressPluginChecksumMismatchError < PluginUpdateError
+end

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -20,7 +20,7 @@ class PluginVerifier
   def verify_checksums
     puts("==> Verifying checksums...")
     checksums = fetch_checksums
-    return if checksums.nil?
+    raise WordPressPluginChecksumsNotFound, "Could not download checksum information for #{@slug}" if checksums.nil?
 
     checksums.each do |file, hashes|
       checksum = hashes["sha256"]

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -1,0 +1,52 @@
+require_relative "./error_mixin"
+
+require "digest"
+
+#
+# This class verifies that the files in a plugin mirrored from wordpress.org are
+# consistent with the checksums that WordPress makes available via a JSON API.
+#
+class PluginVerifier
+  attr_reader :slug, :full_path_to_clone, :checksum_url
+
+  @@checksum_api = "https://downloads.wordpress.org/plugin-checksums/".freeze
+
+  def initialize(slug, version, path)
+    @slug = slug
+    @full_path_to_clone = path
+    @checksum_url = [@@checksum_api, @slug, version + ".json"].join("/")
+  end
+
+  def verify_checksums
+    puts("==> Verifying checksums...")
+    checksums = fetch_checksums
+    return if checksums.nil?
+
+    checksums.each do |file, hashes|
+      checksum = hashes["sha256"]
+      calculated_checksum = calculate_checksum(File.join(@full_path_to_clone, file))
+      if calculated_checksum != checksum
+        raise WordPressPluginChecksumMismatchError, "#{file} checksum mismatch. Expected: #{checksum}, Calculated: #{calculated_checksum}"
+      end
+    end
+  end
+
+  private
+
+  def calculate_checksum(path)
+    Digest::SHA256.file(path).hexdigest
+  end
+
+  def fetch_checksums
+    puts("==> Querying api.wordpress.org for checksums ...")
+    api_info = `curl -s #{@checksum_url}`
+    raise WordPressPluginApiError, "No WordPress API info available for #{@slug}" if api_info.nil?
+
+    begin
+      checksum_info = JSON.parse(api_info)
+    rescue JSON::ParserError => e
+      raise WordPressPluginApiError, e.message
+    end
+    checksum_info["files"]
+  end
+end

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require_relative "./lib/error_mixin"
+require_relative "./lib/plugin_verifier"
 
 require "bundler/setup"
 require "dotenv"
@@ -98,6 +99,8 @@ class PluginUpdater
     puts "==> Committing and tagging the repo with full tag..."
     commit_and_tag
     clean_local_files
+    verifier = PluginVerifier.new(@slug, @latest_wordpress_version, @full_path_to_clone)
+    verifier.verify_checksums # Raises WordPressPluginChecksumMismatchError
     `git -C #{@full_path_to_clone} status`
     puts "==> Updating the GitHub repo..."
     if dry_run?
@@ -326,6 +329,10 @@ class PluginLibraryUpdater
       rescue WordPressPluginUnzipError => e
         @failed_updates[plugin.slug] =
           e.message.empty? ? "could not unzip archive for #{plugin.slug}" : e.message
+        next plugin
+      rescue WordPressPluginChecksumMismatchError => e
+        @failed_updates[plugin.slug] =
+          e.message.empty? ? "could not verify file checksums for #{plugin.slug}" : e.message
         next plugin
       end
       if !plugin.repos_need_updating?

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require_relative "./lib/error_mixin"
+
 require "bundler/setup"
 require "dotenv"
 require "English"
@@ -8,35 +10,6 @@ require "rubygems"
 require "zip"
 
 Dotenv.load
-
-# Generic error class, can be caught but should not be raised.
-class PluginUpdateError < StandardError
-end
-
-# Could not retrieve information about a given plugin.
-class WordPressPluginApiError < PluginUpdateError
-end
-
-# Could retrieve API information but it included an error.
-class WordPressPluginJSONContainsError < PluginUpdateError
-  attr_reader :reason
-  def initialize(msg = "Error from wordpress.org", reason = "")
-    @reason = reason
-    super(msg)
-  end
-end
-
-# Could not download a .zip file for a given plugin.
-class WordPressPluginDownloadError < PluginUpdateError
-end
-
-# Could not unzip the .zip file for a given plugin.
-class WordPressPluginUnzipError < PluginUpdateError
-end
-
-# Could not perform Git action on repo. Only useful for interacting with remotes.
-class GitError < PluginUpdateError
-end
 
 # A PluginUpdater is a representation of a GitHub repository that mirrors a
 # plugin from wordpress.org. PluginUpdaters are responsible for updating

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -97,6 +97,7 @@ class PluginUpdater
     extract_zip(@zip_file, Dir.pwd)
     puts "==> Committing and tagging the repo with full tag..."
     commit_and_tag
+    clean_local_files
     `git -C #{@full_path_to_clone} status`
     puts "==> Updating the GitHub repo..."
     if dry_run?
@@ -126,6 +127,10 @@ class PluginUpdater
     credentials = ENV.fetch("GH_ACCOUNT_USERNAME") + ":" + ENV.fetch("GH_ACCOUNT_TOKEN") + "@"
     url = "https://github.com/" + ENV.fetch("GH_ORG_NAME") + "/" + @slug + ".git"
     url.insert(8, credentials)
+  end
+
+  def clean_local_files
+    `git -C #{@full_path_to_clone} clean -fd`
   end
 
   def commit_and_tag

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -330,6 +330,10 @@ class PluginLibraryUpdater
         @failed_updates[plugin.slug] =
           e.message.empty? ? "could not unzip archive for #{plugin.slug}" : e.message
         next plugin
+      rescue WordPressPluginChecksumsNotFound => e
+        @failed_updates[plugin.slug] =
+          e.message.empty? ? "could not download checksum data for #{plugin.slug}" : e.message
+        next plugin
       rescue WordPressPluginChecksumMismatchError => e
         @failed_updates[plugin.slug] =
           e.message.empty? ? "could not verify file checksums for #{plugin.slug}" : e.message


### PR DESCRIPTION
Follow-up to INC-201: the mirror script validates files mirrored from wordpress.org.

You can see an example of the JSON data used to verify files here:

https://downloads.wordpress.org/plugin-checksums/woocommerce/8.6.0.json

## Design notes

* This PR contains a small amount of refactoring to ensure that we do not add too many new lines to the mirror script which is already long. It does _not_ attempt a full refactor, but that would be a good addition to a separate PR.
* This PR does not add to the GitHub workflows. This would need a new top-level script which ideally would include some more aggressive refactoring, so that's left to future PR.

## Testing

1. Make sure your `.env` is set up to run both scripts as dry runs and to force all actions across the library.
2. Run the `apply-major-version-tags` script in dry-run mode to ensure that this PR does not introduce a regression.
3. Run the `mirror-wordpress-plugins` script in dry-run mode:
  1. Ensure that you see the text `==> Verifying checksums...` in the output for each plugin
  2. Ensure that the script runs to completion