### PR TITLE
Fix/plugin checksum validation

### DIFF
--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -10,6 +10,13 @@ class PluginVerifier
   attr_reader :slug, :full_path_to_clone, :checksum_url
 
   @@checksum_api = "https://downloads.wordpress.org/plugin-checksums".freeze
+  # .git is from jw-player-7-for-wp
+  # Gruntfile.js from simple-lightbox
+  # README.md from Widget-CSS-Classes
+  @@ignored_files = ["readme", "readme.txt", "readme.md", "readme.html", "README",
+    "README.txt", "README.md", "README.html", "changelog",
+    "changelog.txt", "ChangeLog", "CHANGELOG", "Gruntfile.js",
+    ".git"]
 
   def initialize(slug, version, path)
     @slug = slug
@@ -24,6 +31,8 @@ class PluginVerifier
     raise WordPressPluginChecksumsNotFound, "Could not download checksum information for #{@slug}" if checksums.nil?
 
     checksums.each do |file, hashes|
+      next if @@ignored_files.include?(file)
+
       checksum = hashes["sha256"]
       path = File.join(@full_path_to_clone, file)
       if !File.file?(path)

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -50,6 +50,7 @@ class PluginVerifier
     puts("==> Querying api.wordpress.org for checksums ...")
     api_info = `curl -s #{@checksum_url}`
     raise WordPressPluginChecksumsNotFound, "No plugin checksums available for #{@slug} v#{@clean_version}" if api_info.nil?
+    raise WordPressPluginChecksumsNotFound, "No plugin checksums available for #{@slug} v#{@clean_version}" if api_info == "Not found"
 
     begin
       checksum_info = JSON.parse(api_info)

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -49,7 +49,7 @@ class PluginVerifier
   def fetch_checksums
     puts("==> Querying api.wordpress.org for checksums ...")
     api_info = `curl -s #{@checksum_url}`
-    raise WordPressPluginApiError, "No WordPress API info available for #{@slug}" if api_info.nil?
+    raise WordPressPluginChecksumsNotFound, "No plugin checksums available for #{@slug} v#{@clean_version}" if api_info.nil?
 
     begin
       checksum_info = JSON.parse(api_info)

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -30,13 +30,17 @@ class PluginVerifier
         raise WordPressPluginChecksumMismatchError, "#{file} checksum mismatch. File does not exist in GitHub repository."
       end
       calculated_checksum = calculate_checksum(path)
-      if calculated_checksum != checksum
+      if !checksums_match?(checksum, calculated_checksum)
         raise WordPressPluginChecksumMismatchError, "#{file} checksum mismatch. Expected: #{checksum}, Calculated: #{calculated_checksum}"
       end
     end
   end
 
   private
+
+  def checksums_match?(expected, calculated)
+    (expected.is_a?(Array) && expected.include?(calculated)) || (expected.is_a?(String) && calculated === expected)
+  end
 
   def calculate_checksum(path)
     Digest::SHA256.file(path).hexdigest

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -14,7 +14,8 @@ class PluginVerifier
   def initialize(slug, version, path)
     @slug = slug
     @full_path_to_clone = path
-    @checksum_url = [@@checksum_api, @slug, version + ".json"].join("/")
+    @clean_version = version.start_with?("v") ? version[1..] : version
+    @checksum_url = [@@checksum_api, @slug, @clean_version + ".json"].join("/")
   end
 
   def verify_checksums

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -9,7 +9,7 @@ require "digest"
 class PluginVerifier
   attr_reader :slug, :full_path_to_clone, :checksum_url
 
-  @@checksum_api = "https://downloads.wordpress.org/plugin-checksums/".freeze
+  @@checksum_api = "https://downloads.wordpress.org/plugin-checksums".freeze
 
   def initialize(slug, version, path)
     @slug = slug

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -13,10 +13,8 @@ class PluginVerifier
   # .git is from jw-player-7-for-wp
   # Gruntfile.js from simple-lightbox
   # README.md from Widget-CSS-Classes
-  @@ignored_files = ["readme", "readme.txt", "readme.md", "readme.html", "README",
-    "README.txt", "README.md", "README.html", "changelog",
-    "changelog.txt", "ChangeLog", "CHANGELOG", "Gruntfile.js",
-    ".git"]
+  @@ignored_files = ["readme", "readme.txt", "readme.md", "readme.html", "changelog",
+    "changelog.txt", "Gruntfile.js", ".git"]
 
   def initialize(slug, version, path)
     @slug = slug
@@ -31,7 +29,7 @@ class PluginVerifier
     raise WordPressPluginChecksumsNotFound, "Could not download checksum information for #{@slug}" if checksums.nil?
 
     checksums.each do |file, hashes|
-      next if @@ignored_files.include?(file)
+      next if @@ignored_files.include?(file.downcase)
 
       checksum = hashes["sha256"]
       path = File.join(@full_path_to_clone, file)

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -19,7 +19,7 @@ class PluginVerifier
   end
 
   def verify_checksums
-    puts("==> Verifying checksums...")
+    puts("==> Verifying checksums for #{@slug} v#{@clean_version}...")
     checksums = fetch_checksums
     raise WordPressPluginChecksumsNotFound, "Could not download checksum information for #{@slug}" if checksums.nil?
 

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -25,7 +25,11 @@ class PluginVerifier
 
     checksums.each do |file, hashes|
       checksum = hashes["sha256"]
-      calculated_checksum = calculate_checksum(File.join(@full_path_to_clone, file))
+      path = File.join(@full_path_to_clone, file)
+      if !File.file?(path)
+        raise WordPressPluginChecksumMismatchError, "#{file} checksum mismatch. File does not exist in GitHub repository."
+      end
+      calculated_checksum = calculate_checksum(path)
       if calculated_checksum != checksum
         raise WordPressPluginChecksumMismatchError, "#{file} checksum mismatch. Expected: #{checksum}, Calculated: #{calculated_checksum}"
       end


### PR DESCRIPTION
In the [last workflow](https://github.com/dxw-wordpress-plugins/mirror-wordpress-plugins/actions/runs/11129541779/job/30926868120) we had this summary report:

```shell
==> Failed to update the following 1 plugin(s):

*** wp-nested-pages failed to update with message:
783: unexpected token at 'file not found'
```

that 'not found' was difficult to debug on `main` but now we have #54 I have a draft script that runs checksum validation over the whole org and the 'not found' came from the call to the checksum API.

This PR fixes that and adds a number of other changes that are either refactoring or fixes for issues we couldn't see before.

## Output of a run over the whole org

This is the (useful) output of a full run of the new script, which will be in the next PR after #54 

```shell
-----------------------------------------------------------------------
==> Failed to update the following 17 plugin(s):

*** ics-calendar failed to update with message:
could not verify file checksums for ics-calendar: functions.php checksum mismatch. Expected: d5ff21732672425ad7f1916b079c643c36973526d7a443adeb07cf0c263af410, Calculated: 153ab47710344e5395258804245ed0662b849ff915a5a34b60ae177d5caf0604

*** jetpack failed to update with message:
could not verify file checksums for jetpack: 3rd-party/beaverbuilder.php checksum mismatch. Expected: 9605287b64a505ccbeaac6974d5a07fba8ddd5e38aed020c15c9d5c1792ebbf9, Calculated: ff9449069a09e0c9efc23b4d891b0758304ae8459e9605171cfbd2588e13981c

*** visual-sitemap failed to update with message:
could not verify file checksums for visual-sitemap: languages/visual-sitemap-ach.mo checksum mismatch. File does not exist in GitHub repository.

*** wp-updates-notifier failed to update with message:
could not verify file checksums for wp-updates-notifier: wp-updates-notifier.php checksum mismatch. File does not exist in GitHub repository.

*** wp-most-popular failed to update with message:
could not verify file checksums for wp-most-popular: banner-1544x500.png checksum mismatch. File does not exist in GitHub repository.

*** user-domain-whitelist failed to update with message:
could not download checksum data for user-domain-whitelist: No plugin checksums available for user-domain-whitelist v1.5.1

*** snack-bar failed to update with message:
could not download checksum data for snack-bar: No plugin checksums available for snack-bar v0.1.3

*** better-author-bio failed to update with message:
could not verify file checksums for better-author-bio: screenshot checksum mismatch. File does not exist in GitHub repository.

*** Widget-CSS-Classes failed to update with message:
could not verify file checksums for Widget-CSS-Classes: css/widget-css-classes.css checksum mismatch. File does not exist in GitHub repository.

*** simple-lightbox failed to update with message:
could not verify file checksums for simple-lightbox: grunt/jshint.js checksum mismatch. File does not exist in GitHub repository.

*** default-featured-image failed to update with message:
could not verify file checksums for default-featured-image: .wordpress-org/blueprints/blueprint.json checksum mismatch. File does not exist in GitHub repository.

*** user-role-editor failed to update with message:
could not verify file checksums for user-role-editor: blueprint.json checksum mismatch. File does not exist in GitHub repository.

*** wp-algolia failed to update with message:
could not verify file checksums for wp-algolia: vendor/algolia/algoliasearch-client-php/.circleci/index-cleanup.php checksum mismatch. File does not exist in GitHub repository.

*** xml-sitemap-feed failed to update with message:
could not verify file checksums for xml-sitemap-feed: inc/functions.public-sitemap-news.php checksum mismatch. File does not exist in GitHub repository.

*** jw-player-7-for-wp failed to update with message:
could not verify file checksums for jw-player-7-for-wp: admin/ilghera-notice/.git checksum mismatch. File does not exist in GitHub repository.

*** wp-nested-pages failed to update with message:
could not verify file checksums for wp-nested-pages: app/Entities/Post/PostFactory.php checksum mismatch. Expected: 5a4600d878a799cefdb44989c543bc63c7512623b0a0f906c7a2a58acbbf5c05, Calculated: f58d54f129a7cd8ec621fa0d0ca7cede844ccae967d629251d4a60860252867f

*** Wp-Accessibility failed to update with message:
could not verify file checksums for Wp-Accessibility: class-wp-accessibility-toolbar.php checksum mismatch. File does not exist in GitHub repository.
```

* For the ics-calendar `changelog.txt` checksum that is failing, the checksum I calculate locally from the repo is the same checksum I get from the downloaded .zip. I think in cases like this the checksum has been recorded incorrectly in the API.
* I'm not sure why some checksum information is missing, maybe the plugin version is too old? If you check https://downloads.wordpress.org/plugin-checksums/snack-bar/0.1.3.json for example, it does 404.

## Design notes

* It isn't clear to my why some files have multiple checksums, but they do.
* The last commit in this PR is intended to deal with files that we don't want to check and cause errors, such as documentation or Grunt files. However, this does not reduce the number of failing repositories, it seems that where a repo has one file missing it has several directories. I think we need to take a more definite position on whether we see any failure as preventing a mirror. If we do have something like 4948aed5f06362ee3f9866e61036a5ad6918a181 it would need to be more sophisticated to handle things like nested `.git` folders and so on, but that might be a good argument for encouraging manual intervention in these cases?

## Testing

1. Ensure your `.env` is set up for local testing
2. From this branch, dry-run the mirror script to completion