### PR TITLE
NO_CLONE_MIRROR implies no use of a Git repo clone

### DIFF
--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -96,14 +96,20 @@ class PluginUpdater
     # Then unzip into the Git directory
     puts "==> Extracting the latest release from the archive file..."
     extract_zip(@zip_file, Dir.pwd)
-    puts "==> Committing and tagging the repo with full tag..."
-    commit_and_tag
-    clean_local_files
-    verifier = PluginVerifier.new(@slug, @latest_wordpress_version, @full_path_to_clone)
-    verifier.verify_checksums # Raises WordPressPluginChecksumMismatchError
+    if do_not_clone?
+      puts "==> Skipping Git commit and tag operations since the NO_CLONE_MIRROR variable is set"
+      puts "==> Skipping cleaning local repo clone since the NO_CLONE_MIRROR variable is set"
+      puts "==> Skipping plugin checksum verification since the NO_CLONE_MIRROR variable is set"
+    else
+      puts "==> Committing and tagging the repo with full tag..."
+      commit_and_tag
+      clean_local_files
+      verifier = PluginVerifier.new(@slug, @latest_wordpress_version, @full_path_to_clone)
+      verifier.verify_checksums # Raises WordPressPluginChecksumMismatchError
+    end
     `git -C #{@full_path_to_clone} status`
     puts "==> Updating the GitHub repo..."
-    if dry_run?
+    if dry_run? || do_not_clone?
       puts "... -- Dry run mode, no repo pushing taking place --"
     else
       `git -C #{@full_path_to_clone} push`


### PR DESCRIPTION
Previously if the user set NO_CLONE_MIRROR in their .env file we did not clone mirrored repos but we did try to perform other Git operations on those clones, such as add, commit and tag. This resulted in the
operations being applied to this repository which
is confusing behaviour and risks errant commits
being pushed to a feature branch.

This commit adds more defensive behaviour around
Git operations to check the environment variables
as appropriate.

Fixes https://github.com/dxw-wordpress-plugins/mirror-wordpress-plugins/issues/56

## Testing

On this feature branch:

1. Add `NO_CLONE_MIRROR=true` to your `.env` file, make sure you are also running everything in dry run mode
2. Run the mirror script until at least one plugin that can be updated has finished executing
3. Check that you see the new lines in the console output `Skipping Git commit and tag operations...` etc.
4. Check that this repo does not have any unexpected commits or tags 