### PR TITLE
Fix/mirror runs before patch

### DIFF
--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -1,7 +1,7 @@
 name: Mirror WordPress plugins to GitHub
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   schedule:
     - cron: '0 8,12,16 * * *'  # Runs at 08:00, 12:00, and 16:00 UTC
 

--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -3,7 +3,7 @@ name: Mirror WordPress plugins to GitHub
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 8,12,16 * * *'  # Runs at 08:00, 12:00, and 16:00 UTC
+    - cron: 0 8,10,12,14,15,16 * * MON-FRI
 
 jobs:
   mirror-wordpress-plugins:


### PR DESCRIPTION
Previously we have found that the patch workflow in GovPress Tools has run and produced a sequence of PRs (which we have sometimes merged!) but those PRs have not actually upgraded any plugins because the patch workflow has run before the mirror workflow.

This commit changes the mirror workflow to run exactly one hour before the patch workflow. A more permanent solution would be for the GovPress tools workflow to check that an upgrade is available in the mirror repo, rather than just indicated in Patchstack, but this should avoid most of the problems with much less work.

Patch workflow schedule:

    0 9,11,13,15,16,17 * * MON-FRI

New mirror workflow schedule:

    0 8,10,12,14,15,16 * * MON-FRI