### PR TITLE
Fix/tagger cron

### DIFF
--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -1,7 +1,7 @@
 name: Apply major version tags to plugin repos on GitHub
 
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   schedule:
     - cron: '0 */2 * * *'  # Runs every 2 hours
 

--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -3,7 +3,7 @@ name: Apply major version tags to plugin repos on GitHub
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *'  # Runs every 2 hours
+    - cron: 45 8,10,12,14,15,16 * * MON-FRI
 
 jobs:
   apply-major-version-tags:


### PR DESCRIPTION
Run the tagger 45 mins after the mirror workflow

This is to ensure that repos are tagged after they have been updated and before the workflow that automatically patches site repos.
