### PR TITLE
Fix/checksum validation errors being swallowed

### DIFF
--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -34,6 +34,7 @@ class PluginVerifier
       next if @@ignored_files.include?(file.downcase)
       # This is a mistake that comes from using SVN repos and occurred in
       # geo-my-wp v4.5.2
+      next if file.start_with?("trunk/")
       next if @@ignored_exts.any? { |ext| file.downcase.end_with?(ext) }
 
       checksum = hashes["sha256"]

--- a/lib/plugin_verifier.rb
+++ b/lib/plugin_verifier.rb
@@ -15,6 +15,8 @@ class PluginVerifier
   # README.md from Widget-CSS-Classes
   @@ignored_files = ["readme", "readme.txt", "readme.md", "readme.html", "changelog",
     "changelog.txt", "Gruntfile.js", ".git"]
+  # geo-my-wp v4.5.2
+  @@ignored_exts = [".mo", ".po"]
 
   def initialize(slug, version, path)
     @slug = slug
@@ -30,6 +32,9 @@ class PluginVerifier
 
     checksums.each do |file, hashes|
       next if @@ignored_files.include?(file.downcase)
+      # This is a mistake that comes from using SVN repos and occurred in
+      # geo-my-wp v4.5.2
+      next if @@ignored_exts.any? { |ext| file.downcase.end_with?(ext) }
 
       checksum = hashes["sha256"]
       path = File.join(@full_path_to_clone, file)

--- a/mirror-wordpress-plugins
+++ b/mirror-wordpress-plugins
@@ -353,6 +353,12 @@ class PluginLibraryUpdater
       begin
         plugin.update_github_mirror unless plugin.topics.include? PluginUpdater.skip_mirror_topic
         @updated_plugins[plugin.slug] = plugin.latest_wordpress_version
+      rescue WordPressPluginChecksumsNotFound => e
+        @failed_updates[plugin.slug] = e.message
+        plugin.cleanup
+      rescue WordPressPluginChecksumMismatchError => e
+        @failed_updates[plugin.slug] = e.message
+        plugin.cleanup
       rescue PluginUpdateError => e
         @failed_updates[plugin.slug] = e.message
         plugin.cleanup


### PR DESCRIPTION
This PR contains three fixes/workarounds to accommodate [geo-my-wp](https://github.com/Fitoussi/geo-my-wp) v4.5.2.

1. A FIX for plugin checksum failures not being visible in GitHub actions. For example in [this action run](https://github.com/dxw-wordpress-plugins/mirror-wordpress-plugins/actions/runs/12751552686/job/35538891001) the following was printed for the plugin:
```shell
==> Checking status of geo-my-wp...
==> Querying GitHub for latest version ...
==> Querying api.wordpress.org for latest version ...
==> geo-my-wp is v4.5.2 on WordPress and v4.5.1 on GitHub
...mirroring to it now
==> Cloning the geo-my-wp GitHub repo...
Cloning into '/home/runner/work/mirror-wordpress-plugins/mirror-wordpress-plugins/geo-my-wp'...
==> Fetching and extracting latest release from wordpress.org
==> Downloading https://downloads.wordpress.org/plugin/geo-my-wp.4.5.2.zip...
==> Deleting existing files in the repo
==> Extracting the latest release from the archive file...
==> Committing and tagging the repo with full tag...
==> Verifying checksums for geo-my-wp v4.5.2...
==> Querying api.wordpress.org for checksums ...
==> Cleaning up downloaded files...
```
but the plugin did not update, because the error was swallowed. 
1. A WORKAROUND for incorrect checksums in language pack files. It seems reasonable to ignore these as they do not contain executable Javascript or PHP and they apply to logged-in users only.
1. A WORKAROUND for extra checksums that should not have been added to the JSON for files in a `trunk/` folder. I believe this is a mistake due to converting from Git to SVN and so can be ignored. The extra paths can be seen [in the JSON here](https://downloads.wordpress.org/plugin-checksums/geo-my-wp/4.5.2.json) by pretty-printing the JSON in a browser and searching for `trunk`.

## Testing

1. Clone this repo and checkout the `main` branch

2. Go to line 281 in `mirror-wordpress-plugins` and add:
```ruby
   projects.each do |project|
      next unless project["name"] == "geo-my-wp"
```
so you don't have to iterate over all 700+ repos.

3. Make sure your `.env` file is something like this, there are more instructions in the README:
```shell
GH_ACCOUNT_USERNAME=<from-1password-or-use-your-own-account>
GH_ACCOUNT_TOKEN=<secret-from-1password-or-create-a-PATH>
GH_ORG_NAME=dxw-wordpress-plugins
DRY_RUN_MIRROR=true
FORCE_UPDATE_MIRROR=false
NO_DOWNLOAD_MIRROR=false
NO_CLONE_MIRROR=false
FORCE_ANNOTATION=false
ANNOTATE_SKIPPED_REPOS=false
DRY_RUN_TAGGER=true
FORCE_UPDATE_TAGGER=true
```

4. Run `./mirror-wordpress-plugins --dry-run` and notice that it runs to completion without error
5. Delete the downloaded files starting with `geo-my-wp`
6. Checkout this branch and run the plugin mirror again, it should run without error
7. Delete the downloaded files starting with `geo-my-wp`
8. To check the error reporting, open `./lib/plugin_verifier.rb` and comment out some of the changes from this branch
9. Re-run the plugin mirror and you should see the errors the workaround here are intended to avoid