### PR TITLE
Replace the keepalive workflow

### DIFF
--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -45,13 +45,6 @@ jobs:
         run: |
           ./apply-major-version-tags
 
-      - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@2.0.1
-        with:
-          commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
-          committer_username: dxw-govpress-tools
-          committer_email: team+govpress-tools@govpress.com
-
       - name: Alert Slack if failure
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.23.0
@@ -60,3 +53,11 @@ jobs:
           slack-message: "The scheduled task to apply major tags to GitHub plugin repos [EXPERIMENTAL BRANCH] has failed. Check the workflow history for more information: https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/actions/workflows/tagger.yml, and see the documentation for possible causes: https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/blob/main/README.md"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c

--- a/.github/workflows/wordpress-mirror.yml
+++ b/.github/workflows/wordpress-mirror.yml
@@ -47,13 +47,6 @@ jobs:
         run: |
           ./mirror-wordpress-plugins
 
-      - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@2.0.1
-        with:
-          commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
-          committer_username: dxw-govpress-tools
-          committer_email: team+govpress-tools@govpress.com
-
       - name: Alert Slack if failure
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.23.0
@@ -62,3 +55,11 @@ jobs:
           slack-message: "The scheduled task to mirror WordPress plugins to GitHub has failed. Check the workflow history for more information: https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/actions/workflows/main.yml, and see the documentation for possible causes: https://github.com/dxw-wordpress-plugins/mirror-gitlab-plugins/blob/main/README.md"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c


### PR DESCRIPTION
Scheduled workflows in this repository tend to timeout, which means that we need a keepalive workflow to ensure that any operations that run over the whole plugin library run to completion.

The workflow we used before is this:

https://github.com/gautamkrishnar/keepalive-workflow

and currently has a notice on the repo page:

    Access to this repository has been disabled by GitHub Staff
    due to a violation of GitHub's terms of service. If you are
    the owner of the repository, you may reach out to GitHub
    Support for more information.

To ensure that the actions do not fail, this commit replaces that workflow with this one:

    https://github.com/liskin/gh-workflow-keepalive/

Pinned to the commit we reviewed, which was:

    f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c
